### PR TITLE
Automatically decode emails that are quoted-printable

### DIFF
--- a/src/MailHog.php
+++ b/src/MailHog.php
@@ -251,6 +251,11 @@ class MailHog extends Module
    */
   protected function getEmailBody($email)
   {
+    if (!empty($email->Content->Headers->{'Content-Transfer-Encoding'}) &&
+      in_array('quoted-printable', $email->Content->Headers->{'Content-Transfer-Encoding'})
+    ) {
+      return quoted_printable_decode($email->Content->Body);
+    }
     return $email->Content->Body;
   }
 


### PR DESCRIPTION
Hello,

I have a project that I’m working on where I need to compare some strings using seeInOpenEmailBody(). The problem is that the text is quoted-printable making the strings hit forced line wraps.

This is a rudimentary attempt, but I was curious if you’d be interested in adding a feature to allow decoding of emails. I wasn’t sure if it should be a new method, an optional parameter to what exists, or some other implementation.

Thanks for your work on this project, it’s been super useful.