### PR TITLE
Enable uppercase property matching

### DIFF
--- a/src/MailHog.php
+++ b/src/MailHog.php
@@ -444,7 +444,7 @@ class MailHog extends Module
       ) {
           $property = quoted_printable_decode($property);
       }
-      if (strpos($property, '=?utf-8?Q?') !== false && extension_loaded('mbstring')) {
+      if (strpos(strtolower($property), '=?utf-8?q?') !== false && extension_loaded('mbstring')) {
         $property = mb_decode_mimeheader($property);
       }
     }


### PR DESCRIPTION
Solved a bug where the subject property created by PHPMailer was not translated and thus the test ```$I->seeInOpenedEmailSubject('This is å wéird Swödish subjäct')``` was causing problems for me.

The if-clause checked only for ```=?utf-8?Q?``` but PHPMailer starts its subjects with ```=?UTF-8?Q?```.

With the extra conversion to lowercase we should be on the safe side.