### PR TITLE
Check for date header  before using them.

### DIFF
--- a/src/MailHog.php
+++ b/src/MailHog.php
@@ -511,8 +511,14 @@ class MailHog extends Module
    */
   static function sortEmailsByCreationDatePredicate($emailA, $emailB)
   {
-    $sortKeyA = $emailA->Content->Headers->Date;
-    $sortKeyB = $emailB->Content->Headers->Date;
-    return ($sortKeyA > $sortKeyB) ? -1 : 1;
+    if (isset($emailA->Content->Headers->Date) && isset($emailA->Content->Headers->Date)) {
+      $sortKeyA = $emailA->Content->Headers->Date;
+      $sortKeyB = $emailB->Content->Headers->Date;
+      return ($sortKeyA > $sortKeyB) ? -1 : 1;
+    }
+    else {
+      return -1;
+    }
+
   }
 }


### PR DESCRIPTION
If the Date header is missing, tests fail with a `[PHPUnit\Framework\Exception] Undefined property: stdClass::$Date`. This commit checks to make sure they exist before attempting to sort by them.