### PR TITLE
Fixed passing guzzle options to client

### DIFF
--- a/src/MailHog.php
+++ b/src/MailHog.php
@@ -74,13 +74,10 @@ class MailHog extends Module
     $timeout = 1.0;
     if(isset($this->config['timeout']))
         $timeout = $this->config['timeout'];
-    $this->mailhog = new \GuzzleHttp\Client(['base_uri' => $url, 'timeout' => $timeout]);
-
-    if (isset($this->config['guzzleRequestOptions'])) {
-        foreach ($this->config['guzzleRequestOptions'] as $option => $value) {
-            $this->mailhog->setDefaultOption($option, $value);
-        }
-    }
+    
+    $options = ['base_uri' => $url, 'timeout' => $timeout];
+    
+    $this->mailhog = new \GuzzleHttp\Client(array_merge($options, $this->config['guzzleRequestOptions'] ?? []));
   }
 
   /**


### PR DESCRIPTION
Hi @ericmartel 
Great job first of all. On guzzle 6 there is no `setDefaultOption` method, so I passed the options via constructor.