### PR TITLE
Case-insensitive comparing =?utf-8?Q?

### DIFF
--- a/src/MailHog.php
+++ b/src/MailHog.php
@@ -444,7 +444,7 @@ class MailHog extends Module
       ) {
           $property = quoted_printable_decode($property);
       }
-      if (strpos($property, '=?utf-8?Q?') !== false && extension_loaded('mbstring')) {
+      if (stripos($property, '=?utf-8?Q?') !== false && extension_loaded('mbstring')) {
         $property = mb_decode_mimeheader($property);
       }
     }


### PR DESCRIPTION
RFC 2047 says "'encoding' and 'charset' names are case-independent" - https://tools.ietf.org/html/rfc2047

I have a bug with my case:
=?UTF-8?Q?=D0=98=D0=B7=D0=BC=D0=B5=D0=BD=D0=B5=D0=BD=D0=B8=D1=8F=20?= 

This pr fix it.