### PR TITLE
Allow installation with guzzle 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "ericmartel/codeception-email": "^1.0",
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^6.1 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi,

I love this module and use it in many projects. Unfortunatly I was not able anymore to install it in my newer projects, because the require guzzle 7.0 will your module requires guzzle 6.

So I tied to find out what it would mean to make your module compatible with guzzle 7 and found https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70

As I compared the list with the guzzle components, your module you are using, I found no breaking changes. So I simply updated the `require` section in `composer.json` and hope, this was the full job.

Would be great, if you could have a look and maybe release a new version for us as christmas present. 🎅 