### PR TITLE
Allow guzzle version ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "ericmartel/codeception-email": "^1.0",
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^6.1 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
There are no breaking changes in the guzzle request API and as the exceptions in try/catch all look for \Exception there are no reasons not to allow versions ^6.1 and ^7.x for compatibility